### PR TITLE
FreeeSign::Client#access_token の呼び出し時にアクセストークンがなければ raise するようにした

### DIFF
--- a/lib/freee_sign/client.rb
+++ b/lib/freee_sign/client.rb
@@ -2,6 +2,8 @@
 
 module FreeeSign
   class Client
+    class AccessTokenCreationFailed < StandardError; end
+
     Dir[File.expand_path('client/*.rb', __dir__)].sort.each { |f| require f }
 
     include Request
@@ -20,7 +22,11 @@ module FreeeSign
     end
 
     def access_token
-      @access_token ||= post('/v1/token', payload: credentials).fetch('access_token')
+      response = post('/v1/token', payload: credentials)
+
+      raise AccessTokenCreationFailed, response.to_json unless response.key?('access_token')
+
+      @access_token ||= response['access_token']
     end
 
     # Todo RequestModuleがconnectionを知っている必要があるのだがそれは疎結合にしなくて良いのか？

--- a/spec/freee_sign/client/documents_spec.rb
+++ b/spec/freee_sign/client/documents_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe FreeeSign::Client::Documents do
   describe '#documents' do
     subject { client.documents(params) }
 
+    before do
+      allow_any_instance_of(FreeeSign::Client).to receive(:access_token).and_return('access_token')
+    end
+
     context 'with no params' do
       let(:params) { {} }
 


### PR DESCRIPTION
resolve #

- FreeeSign::Client#access_token を改善した

`fetch` を使用していたのでレスポンス内に `:access_token` がなかった場合エラーになっていた
ない場合は `raise AccessTokenCreationFailed` するようにした

- `POST /v1/token` のテストケースを網羅した

response は以下ドキュメントを参考にした

https://ninja-sign.com/v1/docs#/%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9%E3%83%88%E3%83%BC%E3%82%AF%E3%83%B3/post-v1-token