### PR TITLE
PUT のリクエストヘルパーと検索項目付与を実装した

### DIFF
--- a/lib/freee_sign/client/documents.rb
+++ b/lib/freee_sign/client/documents.rb
@@ -14,6 +14,10 @@ module FreeeSign
       def contract_certificate(document_id)
         get("/v1/documents/#{document_id}/contract_certificate")
       end
+
+      def meta_items(document_id, payload:)
+        put("/v1/documents/#{document_id}/meta", payload: payload)
+      end
     end
   end
 end

--- a/lib/freee_sign/request.rb
+++ b/lib/freee_sign/request.rb
@@ -23,6 +23,15 @@ module FreeeSign
       JSON.parse(response.body)
     end
 
+    def put(path, payload: nil)
+      response = connection.put do |request|
+        set_authorization_header!(request, path)
+        request.url path
+        request.body = payload.to_json
+      end
+      JSON.parse(response.body)
+    end
+
     private
 
     def build_connection(endpoint, headers: {})

--- a/spec/fixtures/items.json
+++ b/spec/fixtures/items.json
@@ -1,0 +1,8 @@
+[
+  {
+    "item_id": 1,
+    "type": "string",
+    "name": "item_display_name",
+    "value": "item_value"
+  }
+]

--- a/spec/freee_sign/client/documents_spec.rb
+++ b/spec/freee_sign/client/documents_spec.rb
@@ -53,29 +53,27 @@ RSpec.describe FreeeSign::Client::Documents do
   describe '#meta_items' do
     subject { client.meta_items(document_id, payload: payload) }
 
-    context 'application/json' do
-      let(:document_id) { 1 }
-      let(:payload) do
-        {
-          item_id: 1,
-          type: 'string',
-          name: 'item_display_name',
-          value: 'item_value'
-        }
-      end
+    let(:document_id) { 1 }
+    let(:payload) do
+      {
+        item_id: 1,
+        type: 'string',
+        name: 'item_display_name',
+        value: 'item_value'
+      }
+    end
 
-      before { stub_put("/v1/documents/#{document_id}/meta", 'items') }
+    before { stub_put("/v1/documents/#{document_id}/meta", 'items') }
 
-      it do
-        subject
-        expect(a_put("/v1/documents/#{document_id}/meta")).to have_been_made.once
-      end
+    it do
+      subject
+      expect(a_put("/v1/documents/#{document_id}/meta")).to have_been_made.once
+    end
 
-      it 'should return a response of items' do
-        meta_items = subject
-        expect(meta_items.first['name']).to eq 'item_display_name'
-        expect(meta_items.first['value']).to eq 'item_value'
-      end
+    it 'should return a response of items' do
+      meta_items = subject
+      expect(meta_items.first['name']).to eq 'item_display_name'
+      expect(meta_items.first['value']).to eq 'item_value'
     end
   end
 end

--- a/spec/freee_sign/client/documents_spec.rb
+++ b/spec/freee_sign/client/documents_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe FreeeSign::Client::Documents do
         subject
         expect(a_put("/v1/documents/#{document_id}/meta")).to have_been_made.once
       end
+
+      it 'should return a response of items'do
+        meta_items = subject
+        expect(meta_items.first['name']).to eq "item_display_name"
+        expect(meta_items.first['value']).to eq "item_value"
+      end
     end
   end
 end

--- a/spec/freee_sign/client/documents_spec.rb
+++ b/spec/freee_sign/client/documents_spec.rb
@@ -49,4 +49,27 @@ RSpec.describe FreeeSign::Client::Documents do
       end
     end
   end
+
+  describe '#meta_items' do
+    subject { client.meta_items(document_id, payload: payload) }
+
+    context 'application/json' do
+      let(:document_id) { 1 }
+      let(:payload) do
+        {
+          item_id: 1,
+          type: "string",
+          name: "item_display_name",
+          value: "item_value"
+        }
+      end
+
+      before { stub_put("/v1/documents/#{document_id}/meta", 'items') }
+
+      it do
+        subject
+        expect(a_put("/v1/documents/#{document_id}/meta")).to have_been_made.once
+      end
+    end
+  end
 end

--- a/spec/freee_sign/client/documents_spec.rb
+++ b/spec/freee_sign/client/documents_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe FreeeSign::Client::Documents do
       let(:payload) do
         {
           item_id: 1,
-          type: "string",
-          name: "item_display_name",
-          value: "item_value"
+          type: 'string',
+          name: 'item_display_name',
+          value: 'item_value'
         }
       end
 
@@ -71,10 +71,10 @@ RSpec.describe FreeeSign::Client::Documents do
         expect(a_put("/v1/documents/#{document_id}/meta")).to have_been_made.once
       end
 
-      it 'should return a response of items'do
+      it 'should return a response of items' do
         meta_items = subject
-        expect(meta_items.first['name']).to eq "item_display_name"
-        expect(meta_items.first['value']).to eq "item_value"
+        expect(meta_items.first['name']).to eq 'item_display_name'
+        expect(meta_items.first['value']).to eq 'item_value'
       end
     end
   end


### PR DESCRIPTION
resolve #13

- Add stub_put and a_put helpers
- 検索項目付与 `/v1/documents/{document_id}/meta` を実装した
- 検索項目付与で返ってきたレスポンスの一部内容を検証する


<img width="867" alt="スクリーンショット 2022-04-15 21 56 28" src="https://user-images.githubusercontent.com/5820754/163577219-718c1ff8-9cfb-4e38-b9ff-0d81ee63a4df.png">

![スクリーンショット 2022-04-15 21 56 14](https://user-images.githubusercontent.com/5820754/163577204-19a1cd13-4c54-420b-9578-63ff907c4a48.png)


🤔 
もう一回、今度は更新日を選んでやってみたら、先に追加したテストメタがなくなってしまった？ `PUT` だから丸っと更新してしまうのか？うーむ

<img width="743" alt="スクリーンショット 2022-04-15 23 13 08" src="https://user-images.githubusercontent.com/5820754/163581369-a4905caf-5131-48b5-8bb2-50a7cd18dfba.png">

![image](https://user-images.githubusercontent.com/5820754/163581419-a6db6014-cbb8-4970-9256-cd5be5de289d.png)
